### PR TITLE
Fix permission handling

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -12,3 +12,4 @@ jobs:
         uses: "ibiqlik/action-yamllint@v3"
         with:
           strict: "true"
+          file_or_dir: "data manifests"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,6 @@
 ---
 jenkins::manage_user: false
-#jenkins::manage_group: true
+# jenkins::manage_group: true
 jenkins::manage_datadirs: false
 
 profile_jenkins::backup::locations:


### PR DESCRIPTION
make Puppet only write permission settings when they are missing

this should no longer overwrite permissions added after deployment

also skip security realm plugin when that line is present to allow updates

fixes #2 